### PR TITLE
Add Twitter feed to homepage

### DIFF
--- a/app/views/homepage/show.html.erb
+++ b/app/views/homepage/show.html.erb
@@ -57,7 +57,7 @@
   </div>
   <div class="grid-container">
     <table>
-      <td> <img src="http://i.imgur.com/n7Qqrxb.png" width= "450" length="550"> </td>
+      <td> <a class="twitter-timeline" data-width="400" data-height="400" href="https://twitter.com/IEEEorg?ref_src=twsrc%5Etfw">Tweets by IEEEorg</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
       <td> <img src="https://www.planetizen.com/sites/all/themes/custom/plnz3/img/Job-listing-samples.png" width="400" length="650"> </td>
       <td> <img src="https://i.pinimg.com/originals/84/37/52/843752af8cfed74ae1a80bc23ba5876b.jpg" width= "300" length="350"> </td>
     </table>


### PR DESCRIPTION
Added Twitter feed to homepage using publish.twitter.com generated HTML code

GitHub Issue #36 

## Pull Request Changes
  - Added Twitter's generated HTML to embed IEEE (placeholder until Sesoc Twitter is established) twitter timeline in page.

## Screenshots (optional)
![screenshot from 2018-10-23 19-00-19](https://user-images.githubusercontent.com/26679374/47401372-f1641600-d6f5-11e8-9ebf-e412d063c894.png)


