### PR TITLE
Add 'About' pages and 'Standards and Resources' pages

### DIFF
--- a/app/assets/stylesheets/about_page.scss
+++ b/app/assets/stylesheets/about_page.scss
@@ -1,0 +1,36 @@
+// Place all the styles related to the homepage controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+// Place all the styles related to the homepage controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+.about-container-main_ {
+  margin-top: 3%;
+  margin-left: 2%;
+  padding-top: 1px;
+  padding-left: 15px;
+  padding-right: 15px;
+  background-color: white;
+  max-width: 65%;
+}
+
+.about-background-block_ {
+  padding-top: 1px;
+  padding-right: 15px;
+  max-width: 92.5%;
+  background-color: #F2F2F2;
+}
+
+.about-container-main_ p {
+  font-size: 14px;
+}
+
+.about-container-main_ h1 {
+  font-size: 35px;
+  font-weight: bold;
+}
+
+.about-information_ {
+  width: 500px;
+}

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,0 +1,10 @@
+class AboutController < ApplicationController
+  def description
+  end
+
+  def goals
+  end
+
+  def membership
+  end
+end

--- a/app/views/about/description.html.erb
+++ b/app/views/about/description.html.erb
@@ -47,44 +47,22 @@
     </div>
   </div>
 
-  <div class = "background-block_">
-    <div class="container-main_">
-      <h1>Employer Scoring</h1>
-      <div class = "information">
-        <p> Every software engineer dreams of working for the top-tier tech firms in
-          and around the world in their lifetime. From merely a professional standpoint,
-          software engineers—outside of personal interest in certain projects—weigh much
-          of their decisions as to where they wish to work based on a firm’s average total
-          compensation. As such, we have compiled a list of 18 companies that pay their
-          software engineers over $110,000.<br><br>Here they are:</p>
-
-          <ol>
-            <li>Facebook: $177,014</li>
-            <li>LinkedIn: $170,839</li>
-            <li>Google: $164,683</li>
-            <li>Arista: $151,648</li>
-            <li>PayPal: $146,795</li>
-            <li>Apple: $138,300</li>
-            <li>Brocade: $132,036</li>
-            <li>Cisco: $130,221</li>
-            <li>Yahoo: $125,366</li>
-            <li>IAC: $120,755</li>
-            <li>Symantec: $120,553</li>
-            <li>Amazon: $118,121</li>
-            <li>Nvidia: $117,804</li>
-            <li>Intel: $117,643</li>
-            <li>KLA-Tencor: $117,167</li>
-            <li>Microsoft: $116,967</li>
-            <li>Oracle: $116,514</li>
-            <li>eBay: $113,549</li>
-          </ol>
-
-        <p> Please note that this information is based on 2016 data and, as such, numbers
-          may have changed—companies may have fallen down or up the list, or new companies
-          may have entered the list that are not listed here. Likewise, this is not a
-          complete list of all companies that have this level of average total compensation—
-          there are, most certainly, more out there.
-        </p>
+  <div class="about-background-block_">
+    <div class="about-container_main_">
+      <h1>What is SoSE?</h1>
+      <div class="about-information_">
+        <p>SoSE stands for Society of Software Engineers. It is an organization that
+          intends to aid everyday software engineers, students studying a
+          software-related major, and those whom find themselves interested in
+          everything software in coming together to network and find one another.
+          <br><br>
+          In addition, SoSE aggregates useful information about local, national, and
+          international events, helpful resources about software, such as tutorials,
+          guides, and software-related books, and links to podcasts and videos.</p>
       </div>
     </div>
   </div>
+
+
+
+</div>

--- a/app/views/about/goals.html.erb
+++ b/app/views/about/goals.html.erb
@@ -47,44 +47,16 @@
     </div>
   </div>
 
-  <div class = "background-block_">
-    <div class="container-main_">
-      <h1>Employer Scoring</h1>
-      <div class = "information">
-        <p> Every software engineer dreams of working for the top-tier tech firms in
-          and around the world in their lifetime. From merely a professional standpoint,
-          software engineers—outside of personal interest in certain projects—weigh much
-          of their decisions as to where they wish to work based on a firm’s average total
-          compensation. As such, we have compiled a list of 18 companies that pay their
-          software engineers over $110,000.<br><br>Here they are:</p>
-
-          <ol>
-            <li>Facebook: $177,014</li>
-            <li>LinkedIn: $170,839</li>
-            <li>Google: $164,683</li>
-            <li>Arista: $151,648</li>
-            <li>PayPal: $146,795</li>
-            <li>Apple: $138,300</li>
-            <li>Brocade: $132,036</li>
-            <li>Cisco: $130,221</li>
-            <li>Yahoo: $125,366</li>
-            <li>IAC: $120,755</li>
-            <li>Symantec: $120,553</li>
-            <li>Amazon: $118,121</li>
-            <li>Nvidia: $117,804</li>
-            <li>Intel: $117,643</li>
-            <li>KLA-Tencor: $117,167</li>
-            <li>Microsoft: $116,967</li>
-            <li>Oracle: $116,514</li>
-            <li>eBay: $113,549</li>
-          </ol>
-
-        <p> Please note that this information is based on 2016 data and, as such, numbers
-          may have changed—companies may have fallen down or up the list, or new companies
-          may have entered the list that are not listed here. Likewise, this is not a
-          complete list of all companies that have this level of average total compensation—
-          there are, most certainly, more out there.
-        </p>
+  <div class="about-background-block_">
+    <div class="about-container_main_">
+      <h1>Goals</h1>
+      <div class="about-information_">
+        <p>SoSE was created to bring technological professionals, students, and
+          hobbyists alike into a friendly, welcoming organization that prides itself
+          in helping everyone achieve life-long learning and success in all things
+          software. Our goals are to maintain a repository of useful software
+          information and be the go-to nexus for software-related events, tutorials,
+          resources, guides, GitHub projects, etc.</p>
       </div>
     </div>
   </div>

--- a/app/views/about/membership.html.erb
+++ b/app/views/about/membership.html.erb
@@ -47,44 +47,12 @@
     </div>
   </div>
 
-  <div class = "background-block_">
-    <div class="container-main_">
-      <h1>Employer Scoring</h1>
-      <div class = "information">
-        <p> Every software engineer dreams of working for the top-tier tech firms in
-          and around the world in their lifetime. From merely a professional standpoint,
-          software engineers—outside of personal interest in certain projects—weigh much
-          of their decisions as to where they wish to work based on a firm’s average total
-          compensation. As such, we have compiled a list of 18 companies that pay their
-          software engineers over $110,000.<br><br>Here they are:</p>
-
-          <ol>
-            <li>Facebook: $177,014</li>
-            <li>LinkedIn: $170,839</li>
-            <li>Google: $164,683</li>
-            <li>Arista: $151,648</li>
-            <li>PayPal: $146,795</li>
-            <li>Apple: $138,300</li>
-            <li>Brocade: $132,036</li>
-            <li>Cisco: $130,221</li>
-            <li>Yahoo: $125,366</li>
-            <li>IAC: $120,755</li>
-            <li>Symantec: $120,553</li>
-            <li>Amazon: $118,121</li>
-            <li>Nvidia: $117,804</li>
-            <li>Intel: $117,643</li>
-            <li>KLA-Tencor: $117,167</li>
-            <li>Microsoft: $116,967</li>
-            <li>Oracle: $116,514</li>
-            <li>eBay: $113,549</li>
-          </ol>
-
-        <p> Please note that this information is based on 2016 data and, as such, numbers
-          may have changed—companies may have fallen down or up the list, or new companies
-          may have entered the list that are not listed here. Likewise, this is not a
-          complete list of all companies that have this level of average total compensation—
-          there are, most certainly, more out there.
-        </p>
+  <div class="about-background-block_">
+    <div class="about-container_main_">
+      <h1>Membership</h1>
+      <div class="about-information_">
+        <p>Anyone can be a member of SoSE! We are an inclusive community welcoming
+          everyone from all walks of life.</p>
       </div>
     </div>
   </div>

--- a/app/views/homepage/show.html.erb
+++ b/app/views/homepage/show.html.erb
@@ -9,38 +9,38 @@
       <div class="dropdown">
         <p class="dropbtn">Future Software Engineers</p>
         <div class="dropdown-content">
-          <%=link_to "What is a Software Engineer", future_engineers_info_path %>
-          <%=link_to "Day in the Life", future_engineers_life_path %>
-          <%=link_to "Career Paths", future_engineers_paths_path %>
+          <%= link_to "What is a Software Engineer", future_engineers_info_path %>
+          <%= link_to "Day in the Life", future_engineers_life_path %>
+          <%= link_to "Career Paths", future_engineers_paths_path %>
         </div>
       </div>
 
       <div class="dropdown">
         <div class="dropbtn">Professional Development</div>
         <div class="dropdown-content">
-          <%=link_to "Exams and Certification", professional_development_exams_path %>
-          <%=link_to "Books", professional_development_books_path %>
-          <%=link_to "Software Engineer of the Future", professional_development_future_path %>
+          <%= link_to "Exams and Certification", professional_development_exams_path %>
+          <%= link_to "Books", professional_development_books_path %>
+          <%= link_to "Software Engineer of the Future", professional_development_future_path %>
         </div>
       </div>
 
       <div class="dropdown">
         <div class="dropbtn">Standards and Resources</div>
         <div class="dropdown-content">
-          <%=link_to "Code of Professional Conduct", standards_resources_conduct_path %>
-          <%=link_to "SE Coding Standards and Best Practices", standards_resources_standards_path%>
-          <%=link_to "Employer Scoring", standards_resources_scoring_path %>
-          <%=link_to "Salaries and Demographics", standards_resources_demographics_path %>
-          <%=link_to "Podcasts", standards_resources_podcasts_path%>
+          <%= link_to "Code of Professional Conduct", standards_resources_conduct_path %>
+          <%= link_to "SE Coding Standards and Best Practices", standards_resources_standards_path%>
+          <%= link_to "Employer Scoring", standards_resources_scoring_path %>
+          <%= link_to "Salaries and Demographics", standards_resources_demographics_path %>
+          <%= link_to "Podcasts", standards_resources_podcasts_path%>
         </div>
       </div>
 
       <div class="dropdown">
         <div class="dropbtn">About SoSE</div>
         <div class="dropdown-content">
-          <a href="#">Link 1</a>
-          <a href="#">Link 2</a>
-          <a href="#">Link 3</a>
+          <%= link_to "What is SoSE?", about_description_path %>
+          <%= link_to "Membership", about_membership_path %>
+          <%= link_to "Goals and Purpose", about_goals_path %>
         </div>
       </div>
     </div>

--- a/app/views/standards_resources/conduct.html.erb
+++ b/app/views/standards_resources/conduct.html.erb
@@ -51,8 +51,29 @@
     <div class="container-main_">
       <h1>Code of Professional Conduct</h1>
       <div class = "information">
-        <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis egestas nibh et pulvinar. Nunc lectus massa, lobortis nec porttitor et, venenatis ut odio. Mauris auctor tincidunt elementum. Fusce eu eros pellentesque, volutpat nulla ac, molestie risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus non posuere urna. Etiam bibendum velit ac nisl pellentesque, sed accumsan augue semper. Aenean nec imperdiet quam. Nulla facilisi. Mauris euismod tempus elit eget faucibus.
-        </p>
+        <ol>
+          <li>PUBLIC – Software engineers shall act consistently with the public interest.</li>
+
+          <li>CLIENT AND EMPLOYER – Software engineers shall act in a manner that is in the
+          best interests of their client and employer consistent with the public interest.</li>
+
+          <li>PRODUCT – Software engineers shall ensure that their products and related modifications
+          meet the highest professional standards possible.</li>
+
+          <li>JUDGMENT – Software engineers shall maintain integrity and independence in their
+          professional judgment.</li>
+
+          <li>MANAGEMENT – Software engineering managers and leaders shall subscribe to and
+          promote an ethical approach to the management of software development and maintenance.</li>
+
+          <li>PROFESSION – Software engineers shall advance the integrity and reputation of the
+          profession consistent with the public interest.</li>
+
+          <li>COLLEAGUES – Software engineers shall be fair to and supportive of their colleagues.</li>
+
+          <li>SELF – Software engineers shall participate in lifelong learning regarding the practice
+          of their profession and shall promote an ethical approach to the practice of the profession.</li>
+        </ol>
       </div>
     </div>
   </div>

--- a/app/views/standards_resources/demographics.html.erb
+++ b/app/views/standards_resources/demographics.html.erb
@@ -51,8 +51,14 @@
     <div class="container-main_">
       <h1>Salaries and Demographics</h1>
       <div class = "information">
-        <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis egestas nibh et pulvinar. Nunc lectus massa, lobortis nec porttitor et, venenatis ut odio. Mauris auctor tincidunt elementum. Fusce eu eros pellentesque, volutpat nulla ac, molestie risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus non posuere urna. Etiam bibendum velit ac nisl pellentesque, sed accumsan augue semper. Aenean nec imperdiet quam. Nulla facilisi. Mauris euismod tempus elit eget faucibus.
-        </p>
+        <ul>
+          <li>Software Engineer: $83,021</li>
+          <li>Junior Software Engineer: $58,784</li>
+          <li>Senior Software Engineer: $110,209</li>
+          <li>Product Manager, Software: $91,272</li>
+          <li>Project Manager, Software: $84,931</li>
+          <li>Program Manager, Software: $104,328</li>
+        <ul>
       </div>
     </div>
   </div>

--- a/app/views/standards_resources/podcasts.html.erb
+++ b/app/views/standards_resources/podcasts.html.erb
@@ -51,7 +51,8 @@
     <div class="container-main_">
       <h1>Podcasts</h1>
       <div class = "information">
-        <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis egestas nibh et pulvinar. Nunc lectus massa, lobortis nec porttitor et, venenatis ut odio. Mauris auctor tincidunt elementum. Fusce eu eros pellentesque, volutpat nulla ac, molestie risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus non posuere urna. Etiam bibendum velit ac nisl pellentesque, sed accumsan augue semper. Aenean nec imperdiet quam. Nulla facilisi. Mauris euismod tempus elit eget faucibus.
+        <p>
+          <a href="https://simpleprogrammer.com/ultimate-list-developer-podcasts/">List of Software Podcasts</a>
         </p>
       </div>
     </div>

--- a/app/views/standards_resources/standards.html.erb
+++ b/app/views/standards_resources/standards.html.erb
@@ -9,38 +9,38 @@
       <div class="dropdown_">
         <p class="dropbtn_">Future Software Engineers</p>
         <div class="dropdown-content_">
-          <%=link_to "What is a Software Engineer", future_engineers_info_path %>
-          <%=link_to "Day in the Life", future_engineers_life_path %>
-          <%=link_to "Career Paths", future_engineers_paths_path %>
+          <%= link_to "What is a Software Engineer", future_engineers_info_path %>
+          <%= link_to "Day in the Life", future_engineers_life_path %>
+          <%= link_to "Career Paths", future_engineers_paths_path %>
         </div>
       </div>
 
       <div class="dropdown_">
         <div class="dropbtn_">Professional Development</div>
         <div class="dropdown-content_">
-          <%=link_to "Exams and Certification", professional_development_exams_path %>
-          <%=link_to "Books", professional_development_books_path %>
-          <%=link_to "Software Engineer of the Future", professional_development_future_path %>
+          <%= link_to "Exams and Certification", professional_development_exams_path %>
+          <%= link_to "Books", professional_development_books_path %>
+          <%= link_to "Software Engineer of the Future", professional_development_future_path %>
         </div>
       </div>
 
       <div class="dropdown_">
         <p class="dropbtn_">Standards and Resources</p>
         <div class="dropdown-content_">
-          <%=link_to "Code of Professional Conduct", standards_resources_conduct_path %>
-          <%=link_to "SE Coding Standards and Best Practices", standards_resources_standards_path%>
-          <%=link_to "Employer Scoring", standards_resources_scoring_path %>
-          <%=link_to "Salaries and Demographics", standards_resources_demographics_path %>
-          <%=link_to "Podcasts", standards_resources_podcasts_path%>
+          <%= link_to "Code of Professional Conduct", standards_resources_conduct_path %>
+          <%= link_to "SE Coding Standards and Best Practices", standards_resources_standards_path%>
+          <%= link_to "Employer Scoring", standards_resources_scoring_path %>
+          <%= link_to "Salaries and Demographics", standards_resources_demographics_path %>
+          <%= link_to "Podcasts", standards_resources_podcasts_path%>
         </div>
       </div>
 
       <div class="dropdown_">
         <p class="dropbtn_">About SoSE</p>
         <div class="dropdown-content_">
-          <a href="#">Link 1</a>
-          <a href="#">Link 2</a>
-          <a href="#">Link 3</a>
+          <%= link_to "What is SoSE?", about_description_path %>
+          <%= link_to "Membership", about_membership_path %>
+          <%= link_to "Goals and Purpose", about_goals_path %>
         </div>
       </div>
 
@@ -51,8 +51,17 @@
     <div class="container-main_">
       <h1>SE Coding Standards and Best Practices</h1>
       <div class = "information">
-        <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis egestas nibh et pulvinar. Nunc lectus massa, lobortis nec porttitor et, venenatis ut odio. Mauris auctor tincidunt elementum. Fusce eu eros pellentesque, volutpat nulla ac, molestie risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus non posuere urna. Etiam bibendum velit ac nisl pellentesque, sed accumsan augue semper. Aenean nec imperdiet quam. Nulla facilisi. Mauris euismod tempus elit eget faucibus.
-        </p>
+        <ol>
+          <li>Good commenting and documentation</li>
+          <li>Avoiding obvious comments on certain lines of code</li>
+          <li>Attention to code spacing and grouping</li>
+          <li>Consistency in naming schemes</li>
+          <li>Avoiding redundancy in code (using helper functions, for example)</li>
+          <li>Organizing your files and folders</li>
+          <li>Maintaining high readability</li>
+          <li>Code refactoring</li>
+          <li>Spaces vs. tabs—being consistent with indentation</li>
+        </ol>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'about/description'
+  get 'about/goals'
+  get 'about/membership'
   get 'future_engineers/info'
   get 'future_engineers/life'
   get 'future_engineers/paths'


### PR DESCRIPTION
## Description
Updated "Link #1", "Link #2", and "Link #3" with "What is SoSE?", "Membership", and "Goals", respectively. Added relevant text, paragraphs, and lists to HTML links under the About links and the Standard and Resources links.

## GitHub Issues
https://github.com/ChapmanCPSC/SE-Society/issues/89
https://github.com/ChapmanCPSC/SE-Society/issues/88

## Pull Request Changes
- Added "about" view
- Added "about" stylesheet
- Updated various HTML links

<img width="212" alt="Screenshot 1" src="https://user-images.githubusercontent.com/19722814/47974141-11cc9280-e05d-11e8-8b75-1f2a18fc160c.png">
<img width="195" alt="Screenshot 2" src="https://user-images.githubusercontent.com/19722814/47974142-12652900-e05d-11e8-9440-4b2c2f98e09e.png">
<img width="179" alt="Screenshot 3" src="https://user-images.githubusercontent.com/19722814/47974152-18f3a080-e05d-11e8-8b01-cff634fff294.png">
<img width="476" alt="Big Text" src="https://user-images.githubusercontent.com/19722814/47977072-05e7cd00-e06b-11e8-8bf8-0f14b33663a2.png">